### PR TITLE
test separately on 0.4 and 0.5 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
release is 0.5 at the moment, but 0.4 is still supported according to REQUIRE